### PR TITLE
SPAC-22-api-calls:  controllers and error handeling on calls

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -55,7 +55,7 @@ unsafe-load-any-extension=no
 extension-pkg-allow-list=
 
 # Minimum supported python version
-py-version = 3.7.2
+py-version = 3.13.2
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or

--- a/Apis/contollers.py
+++ b/Apis/contollers.py
@@ -1,0 +1,26 @@
+import requests
+
+from helpers.api_url import Swpc, UrlEnums
+
+
+class SwpcNoaaApi():
+    def _get(self, url_param: UrlEnums) -> str | bool:
+        url = Swpc.get_url(url_param)
+        data = SwpcNoaaApi.__handel_call(url)
+        return data
+
+    @staticmethod
+    def __handel_call(url: str) -> requests.Response | bool:
+        try:
+            req = requests.get(url, timeout=10)
+            if req.status_code != 200 or req.headers['content-type'] != 'application/json':
+                print(f"Something went wrong while calling: {url}")
+                return False
+            if not req.json():
+                print("Error: Empty response")
+                return False
+            return req.json()
+
+        except Exception as e:
+            print(f"Call error: {e}")
+            return False

--- a/helpers/api_url.py
+++ b/helpers/api_url.py
@@ -1,6 +1,13 @@
-XRAY_FLARES: str = "goes/primary/xray-flares-7-day.json"
-SOLAR_PROBABILITIES: str = "solar_probabilities.json"
-PLANETARY_K: str = "planetary_k_index_1m.json"
+from enum import Enum
 
-def url (data_type: str):
-    return f"https://services.swpc.noaa.gov/json/{data_type}"
+
+class UrlEnums(Enum):
+    XRAY_FLARES: str = "goes/primary/xray-flares-7-day.json"
+    SOLAR_PROBABILITIES: str = "solar_probabilities.json"
+    PLANETARY_K: str = "planetary_k_index_1m.json"
+
+
+class Swpc():
+    @staticmethod
+    def get_url(data_type: UrlEnums) -> str:
+        return f"https://services.swpc.noaa.gov/json/{data_type.value}"

--- a/main.py
+++ b/main.py
@@ -1,5 +1,10 @@
+from Apis.contollers import SwpcNoaaApi
+from helpers.api_url import UrlEnums
+
+
 def main():
-    print('test')
+    data_and_handled = SwpcNoaaApi()._get(UrlEnums.SOLAR_PROBABILITIES)
+    print(data_and_handled)
 
 
 main()


### PR DESCRIPTION
- Added Url enums
- added controllers file
- added handeling logic


HOW TO TEST

call the `SwpcNoaaApi()` in main then call the `SwpcNoaaApi()._call()` function enter the enum param for the end point you want to access. You should get all the data in json that you need.